### PR TITLE
Add KimiK2Agent with execution toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,10 @@ Kimi K2 Instruct führt in vielen Benchmarks:
 | **AIME 2024** | **69.6%** | 59.4% | 46.5% |
 | **ZebraLogic** | **89.0%** | 84.0% | 58.5% |
 
+
+## 🛠️ Kimi K2 Agent
+
+Neue Agent-Klasse `KimiK2Agent` mit direktem Zugriff auf das Execution Toolkit. Befehle aus einer Plan-Datei werden sequenziell ausgeführt.
 ## 📄 Lizenz
 
 Modified MIT License - Siehe [Hugging Face Modell-Seite](https://huggingface.co/moonshotai/Kimi-K2-Instruct)

--- a/execution_toolkit.py
+++ b/execution_toolkit.py
@@ -1,0 +1,40 @@
+import os
+import subprocess
+from typing import Dict
+
+
+def read_file(path: str) -> str:
+    """Read a file and return its contents."""
+    with open(path, 'r', encoding='utf-8') as f:
+        return f.read()
+
+
+def write_file(path: str, content: str) -> None:
+    """Write content to a file, creating it if necessary."""
+    with open(path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+
+def delete_file(path: str) -> None:
+    """Delete a file if it exists."""
+    if os.path.exists(path):
+        os.remove(path)
+
+
+def execute_shell_command(command: str, timeout: int = 30) -> Dict[str, str]:
+    """Execute an arbitrary shell command and capture output."""
+    try:
+        proc = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return {
+            "stdout": proc.stdout,
+            "stderr": proc.stderr,
+            "exit_code": proc.returncode,
+        }
+    except subprocess.TimeoutExpired:
+        return {"stdout": "", "stderr": "Execution timed out", "exit_code": -1}

--- a/kimi_k2_agent.py
+++ b/kimi_k2_agent.py
@@ -1,0 +1,57 @@
+import threading
+from typing import Optional
+from kimi_client import KimiClient
+from execution_toolkit import execute_shell_command, read_file, write_file, delete_file
+
+
+class KimiK2Agent:
+    """Autonomous agent with direct execution capabilities."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.client = KimiClient(api_key=api_key)
+        self.stop_requested = False
+
+    def run_command(self, command: str) -> str:
+        result = execute_shell_command(command)
+        output = []
+        if result["stdout"]:
+            output.append(result["stdout"])
+        if result["stderr"]:
+            output.append(result["stderr"])
+        output.append(f"exit_code={result['exit_code']}")
+        return "\n".join(output)
+
+    def stop(self):
+        self.stop_requested = True
+
+    def run_plan(self, plan: str):
+        """Simple loop executing shell commands from a plan string."""
+        for line in plan.splitlines():
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            if self.stop_requested:
+                break
+            print(f"$ {line}")
+            result = self.run_command(line)
+            print(result)
+
+
+def run_agent(plan_path: str, api_key: Optional[str] = None):
+    agent = KimiK2Agent(api_key)
+    with open(plan_path, 'r', encoding='utf-8') as f:
+        plan = f.read()
+    agent_thread = threading.Thread(target=agent.run_plan, args=(plan,), daemon=True)
+    agent_thread.start()
+    try:
+        while agent_thread.is_alive():
+            agent_thread.join(0.5)
+    except KeyboardInterrupt:
+        agent.stop()
+        agent_thread.join()
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python3 kimi_k2_agent.py <plan_file>")
+    else:
+        run_agent(sys.argv[1])


### PR DESCRIPTION
## Summary
- implement an `execution_toolkit` with read/write/delete and shell command capabilities
- create `KimiK2Agent` that runs shell commands from a plan
- document new agent in README

## Testing
- `pip install together python-dotenv pydantic openai`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68817a08c0b88322a0b1a98849d40660