### PR TITLE
Remove Together AI references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Vollständiger Client für **Kimi K2 Instruct** - das State-of-the-Art MoE Model
 
 ## ✨ Features
 
-- **🎯 Echtes Kimi K2 Instruct Modell** über Together AI
+- **🎯 Echtes Kimi K2 Instruct Modell** über Moonshot AI
 - **💻 CLI Chat** - Interaktive Kommandozeilen-Oberfläche
 - **🖥️ GUI Chat** - Moderne grafische Benutzeroberfläche
 - **⚡ Streaming Support** - Live-Antworten
@@ -18,14 +18,14 @@ Vollständiger Client für **Kimi K2 Instruct** - das State-of-the-Art MoE Model
 
 ### 1. API-Key einrichten
 
-1. **Erstellen Sie einen API-Key bei Together AI:**
+1. **Erstellen Sie einen API-Key bei Moonshot AI:**
    ```
-   https://api.together.xyz/settings/api-keys
+   https://platform.moonshot.ai
    ```
 
 2. **Setzen Sie den API-Key in der `.env`-Datei:**
    ```bash
-   TOGETHER_API_KEY=your_api_key_here
+   MOONSHOT_API_KEY=sk-your_api_key_here
    ```
 
 ### 2. Starten
@@ -213,7 +213,7 @@ if result["finish_reason"] == "tool_calls":
 | **Architektur** | Mixture-of-Experts (MoE) |
 | **Kontext** | 128K Token |
 | **Spezialisierung** | Coding, Reasoning, Tool Use |
-| **Provider** | Together AI |
+| **Provider** | Moonshot AI |
 | **Training** | 15.5T Token mit Muon Optimizer |
 
 ## 🎯 Anwendungsfälle
@@ -241,15 +241,15 @@ if result["finish_reason"] == "tool_calls":
 ### API-Key Probleme
 
 ```bash
-❌ Fehler: Bitte setzen Sie TOGETHER_API_KEY in der .env-Datei
+❌ Fehler: Bitte setzen Sie MOONSHOT_API_KEY in der .env-Datei
 ```
 
 **Lösung:**
-1. Gehen Sie zu: https://api.together.xyz/settings/api-keys
+1. Besuchen Sie https://platform.moonshot.ai
 2. Erstellen Sie einen neuen API-Key
 3. Setzen Sie ihn in der `.env`-Datei:
    ```
-   TOGETHER_API_KEY=your_actual_api_key_here
+   MOONSHOT_API_KEY=sk-your_actual_api_key_here
    ```
 
 ### Dependencies
@@ -260,7 +260,7 @@ if result["finish_reason"] == "tool_calls":
 
 **Lösung:**
 ```bash
-pip3 install together python-dotenv pydantic
+pip3 install python-dotenv pydantic openai
 ```
 
 ### GUI Probleme
@@ -324,7 +324,7 @@ Modified MIT License - Siehe [Hugging Face Modell-Seite](https://huggingface.co/
 
 ## 🤝 Support
 
-- **Together AI Docs:** https://docs.together.ai/
+- **Moonshot AI Docs:** https://platform.moonshot.ai
 - **Kimi K2 Model Card:** https://huggingface.co/moonshotai/Kimi-K2-Instruct
 - **Issues:** Erstellen Sie ein Issue in diesem Repository
 

--- a/api_info.py
+++ b/api_info.py
@@ -16,12 +16,12 @@ def main():
     print("━" * 60)
     
     # API-Key Status prüfen
-    api_key = os.getenv("TOGETHER_API_KEY", "")
+    api_key = os.getenv("MOONSHOT_API_KEY", "")
     
     if not api_key:
-        print("❌ Kein TOGETHER_API_KEY in .env gefunden")
+        print("❌ Kein MOONSHOT_API_KEY in .env gefunden")
         status = "❌ Nicht konfiguriert"
-    elif api_key in ["demo_key_please_replace", "your_together_api_key_here", "your_api_key_here"]:
+    elif api_key == "sk-demo_key_please_replace":
         print("⚠️  Demo-API-Key gefunden - Setup erforderlich")
         status = "⚠️ Setup erforderlich"
     else:
@@ -40,18 +40,18 @@ def main():
     
     print()
     print("🛠️ Setup-Anleitung:")
-    print("1. Gehen Sie zu: https://api.together.xyz/settings/api-keys")
-    print("2. Registrieren Sie sich kostenlos bei Together AI")
+    print("1. Besuchen Sie https://platform.moonshot.ai")
+    print("2. Registrieren Sie sich kostenlos")
     print("3. Erstellen Sie einen neuen API-Key")
     print("4. Bearbeiten Sie die .env-Datei:")
-    print("   TOGETHER_API_KEY=your_actual_api_key_here")
+    print("   MOONSHOT_API_KEY=sk-your_actual_api_key_here")
     print()
     print("🎯 Über Kimi K2 Instruct:")
     print("• State-of-the-Art MoE Modell mit 1 Trillion Parametern")
     print("• 32B Parameter aktiviert pro Forward Pass")
     print("• 128K Token Kontext für umfangreiche Dokumente")
     print("• Spezialisiert auf Coding, Reasoning und Tool Use")
-    print("• Angetrieben von Together AI")
+    print("• Powered by Moonshot AI")
     print()
     print("🚀 Starten:")
     print("• CLI Chat: python3 kimi_chat.py")

--- a/kimi_chat.py
+++ b/kimi_chat.py
@@ -20,7 +20,7 @@ class KimiChatCLI(cmd.Cmd):
 State-of-the-Art MoE Modell mit 1T Parametern (32B aktiviert)
 ✨ Spezialisiert auf Coding, Reasoning und Tool Use
 🌐 128K Token Kontext
-⚡ Angetrieben von Together AI
+⚡ Powered by Moonshot AI
 
 Geben Sie 'help' ein für Kommandos oder chatten Sie direkt los!
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -55,9 +55,9 @@ Geben Sie 'help' ein für Kommandos oder chatten Sie direkt los!
         except Exception as e:
             print(f"❌ Fehler beim Initialisieren: {e}")
             print("\n💡 Setup-Hilfe:")
-            print("1. Gehen Sie zu: https://api.together.xyz/settings/api-keys")
+            print("1. Besuchen Sie: https://platform.moonshot.ai")
             print("2. Erstellen Sie einen API-Key")
-            print("3. Setzen Sie TOGETHER_API_KEY in der .env-Datei")
+            print("3. Setzen Sie MOONSHOT_API_KEY in der .env-Datei")
             sys.exit(1)
     
     def default(self, line):

--- a/kimi_client.py
+++ b/kimi_client.py
@@ -3,12 +3,12 @@
 
 """
 Kimi K2 Instruct Client
-Moderne Python-Client für Kimi K2 Instruct über Together AI
+Python-Client für Kimi K2 Instruct über die Moonshot AI API
 """
 
 import os
 from typing import Iterator, List, Dict, Any, Optional
-from together import Together
+from openai import OpenAI
 from dotenv import load_dotenv
 from pydantic import BaseModel
 
@@ -36,14 +36,14 @@ class KimiClient:
         Initialisiere Kimi K2 Client
         
         Args:
-            api_key: Together AI API Key (optional, wird aus .env geladen)
+            api_key: Moonshot AI API Key (optional, wird aus .env geladen)
         """
-        self.api_key = api_key or os.getenv("TOGETHER_API_KEY")
-        if not self.api_key or self.api_key in ["demo_key_please_replace", "your_api_key_here"]:
-            raise ValueError("TOGETHER_API_KEY ist erforderlich. Bitte in .env-Datei konfigurieren.")
+        self.api_key = api_key or os.getenv("MOONSHOT_API_KEY")
+        if not self.api_key or self.api_key == "sk-demo_key_please_replace":
+            raise ValueError("MOONSHOT_API_KEY ist erforderlich. Bitte in .env-Datei konfigurieren.")
         
-        # Together AI Client
-        self.client = Together(api_key=self.api_key)
+        # Moonshot AI Client (OpenAI kompatibel)
+        self.client = OpenAI(api_key=self.api_key, base_url="https://api.moonshot.ai/v1")
         
         # Standard-Konfiguration
         self.model = os.getenv("KIMI_MODEL", "moonshotai/Kimi-K2-Instruct")  # Korrigiert mit moonshotai/ Prefix
@@ -52,6 +52,10 @@ class KimiClient:
         
         # Conversation State
         self.conversation_history: List[Dict[str, str]] = []
+
+    def simple_chat(self, message: str) -> str:
+        """Shortcut for chat without system prompt."""
+        return self.chat(message)
         
     def chat(self, message: str, system_prompt: Optional[str] = None) -> str:
         """
@@ -222,13 +226,13 @@ class KimiClient:
             "model": self.model,
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
-            "api_provider": "Together AI",
+            "api_provider": "Moonshot AI",
             "conversation_length": len(self.conversation_history)
         }
 
 # Utility-Funktionen
 def test_connection() -> bool:
-    """Teste die Verbindung zu Together AI"""
+    """Teste die Verbindung zu Moonshot AI"""
     try:
         client = KimiClient()
         response = client.chat("Hallo, kannst du mich hören?")
@@ -263,9 +267,9 @@ def main():
     except Exception as e:
         print(f"❌ Fehler: {e}")
         print("\n🔧 Lösungsvorschläge:")
-        print("1. Überprüfen Sie Ihren TOGETHER_API_KEY in der .env-Datei")
-        print("2. Registrieren Sie sich bei: https://api.together.xyz/settings/api-keys")
-        print("3. Installieren Sie Dependencies: pip install together python-dotenv")
+        print("1. Überprüfen Sie Ihren MOONSHOT_API_KEY in der .env-Datei")
+        print("2. Registrieren Sie sich bei: https://platform.moonshot.ai")
+        print("3. Installieren Sie Dependencies: pip install python-dotenv pydantic openai")
 
 if __name__ == "__main__":
     main()

--- a/kimi_gui.py
+++ b/kimi_gui.py
@@ -137,7 +137,7 @@ class KimiGUI:
             self.add_to_chat("Fehler", f"Kimi Client konnte nicht initialisiert werden: {e}", "error")
             messagebox.showerror("Initialisierungsfehler", 
                                f"Fehler beim Laden des Kimi Clients:\n\n{e}\n\n"
-                               "Stellen Sie sicher, dass TOGETHER_API_KEY in der .env-Datei gesetzt ist.")
+                               "Stellen Sie sicher, dass MOONSHOT_API_KEY in der .env-Datei gesetzt ist.")
     
     def update_temp_label(self, value):
         """Aktualisiert das Temperature Label"""

--- a/kimi_gui_modern.py
+++ b/kimi_gui_modern.py
@@ -342,8 +342,8 @@ class ModernKimiGUI:
         self.status_label.pack(side=tk.LEFT, padx=10, pady=5)
         
         # API-Status
-        api_key = os.getenv("TOGETHER_API_KEY", "")
-        if not api_key or api_key in ["demo_key_please_replace", "your_api_key_here"]:
+        api_key = os.getenv("MOONSHOT_API_KEY", "")
+        if not api_key or api_key == "sk-demo_key_please_replace":
             api_status = "❌ API-Key Setup erforderlich"
             color = self.colors['error']
         else:
@@ -714,11 +714,11 @@ def main():
     print("🚀 Starte Moderne Kimi K2 GUI...")
     
     # API-Key prüfen
-    api_key = os.getenv("TOGETHER_API_KEY", "")
-    if not api_key or api_key in ["demo_key_please_replace", "your_api_key_here"]:
+    api_key = os.getenv("MOONSHOT_API_KEY", "")
+    if not api_key or api_key == "sk-demo_key_please_replace":
         print("⚠️  Demo-API-Key erkannt. Bitte konfigurieren Sie einen echten API-Key in der .env-Datei:")
-        print("   TOGETHER_API_KEY=your_actual_api_key_here")
-        print("   Registrierung: https://api.together.xyz/settings/api-keys")
+        print("   MOONSHOT_API_KEY=sk-your_actual_api_key_here")
+        print("   Registrierung: https://platform.moonshot.ai")
     
     app = ModernKimiGUI()
     app.run()

--- a/main.py
+++ b/main.py
@@ -28,16 +28,16 @@ def main():
         
         # Einfacher Test
         print(f"\n💬 Teste einfachen Chat...")
-        response = kimi.simple_chat("Hallo! Kannst du auf Deutsch antworten?")
+        response = kimi.chat("Hallo! Kannst du auf Deutsch antworten?")
         print(f"\n🤖 Kimi antwortet:")
         print(response)
         
     except ValueError as e:
         print(f"❌ Konfigurationsfehler: {e}")
         print("\n💡 Setup-Hilfe:")
-        print("1. Gehen Sie zu: https://api.together.xyz/settings/api-keys")
+        print("1. Besuchen Sie: https://platform.moonshot.ai")
         print("2. Erstellen Sie einen API-Key")
-        print("3. Setzen Sie TOGETHER_API_KEY in der .env-Datei")
+        print("3. Setzen Sie MOONSHOT_API_KEY in der .env-Datei")
         
     except Exception as e:
         print(f"❌ Fehler bei der API-Verbindung: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-together>=1.0.0
 python-dotenv>=1.0.0
 pydantic>=2.0.0
 tkinter-modern>=1.0.0

--- a/start_kimi.command
+++ b/start_kimi.command
@@ -23,10 +23,10 @@ echo
 
 # Dependencies prüfen
 echo -e "${BLUE}🔧 Prüfe Dependencies...${NC}"
-python3 -c "import together, dotenv, pydantic" 2>/dev/null
+python3 -c "import dotenv, pydantic" 2>/dev/null
 if [ $? -ne 0 ]; then
     echo -e "${YELLOW}⚠️  Installiere fehlende Dependencies...${NC}"
-    pip3 install together python-dotenv pydantic --quiet
+    pip3 install python-dotenv pydantic --quiet
     echo -e "${GREEN}✅ Dependencies installiert${NC}"
 fi
 
@@ -43,14 +43,14 @@ python3 -c "
 import os
 from dotenv import load_dotenv
 load_dotenv()
-api_key = os.getenv('TOGETHER_API_KEY', '')
-if not api_key or api_key in ['demo_key_please_replace', 'your_api_key_here']:
+api_key = os.getenv('MOONSHOT_API_KEY', '')
+if not api_key or api_key == 'sk-demo_key_please_replace':
     print('❌ Demo-API-Key erkannt - Setup erforderlich!')
     print('📋 Anleitung:')
-    print('   1. Gehen Sie zu: https://api.together.xyz/settings/api-keys')
+    print('   1. Besuchen Sie https://platform.moonshot.ai')
     print('   2. Registrieren Sie sich kostenlos')
     print('   3. Erstellen Sie einen API-Key')
-    print('   4. Bearbeiten Sie .env: TOGETHER_API_KEY=your_actual_key')
+    print('   4. Bearbeiten Sie .env: MOONSHOT_API_KEY=sk-your_actual_key')
     print()
 else:
     print('✅ API-Key konfiguriert')
@@ -108,4 +108,4 @@ echo -e "${CYAN}• 1 Trillion Parameter (32B aktiviert)${NC}"
 echo -e "${CYAN}• 128K Token Kontext${NC}"
 echo -e "${CYAN}• Spezialisiert auf Coding & Reasoning${NC}"
 echo -e "${CYAN}• Tool Use & Function Calling${NC}"
-echo -e "${CYAN}• Angetrieben von Together AI${NC}" 
+echo -e "${CYAN}• Powered by Moonshot AI${NC}"

--- a/start_kimi_elegant.command
+++ b/start_kimi_elegant.command
@@ -69,7 +69,7 @@ check_dependencies() {
     fi
     
     # Package Checks
-    local packages=("together" "python-dotenv" "pydantic")
+    local packages=("python-dotenv" "pydantic")
     local optional=("pyttsx3" "speechrecognition" "pyaudio")
     
     for pkg in "${packages[@]}"; do
@@ -118,7 +118,7 @@ install_dependencies() {
     
     # Required packages
     echo -e "${BLUE}Installing required packages:${NC}"
-    pip3 install together python-dotenv pydantic
+    pip3 install python-dotenv pydantic
     
     echo ""
     echo -e "${BLUE}Installing optional voice packages:${NC}"

--- a/test_simple.py
+++ b/test_simple.py
@@ -14,15 +14,15 @@ load_dotenv()
 def test_api():
     print("🧪 Teste Kimi K2 API-Verbindung...")
     
-    api_key = os.getenv("TOGETHER_API_KEY", "")
+    api_key = os.getenv("MOONSHOT_API_KEY", "")
     
     if not api_key or api_key == "demo_key_please_replace":
         print("❌ Demo-API-Key aktiv - Echter API-Key erforderlich")
         print("\n💡 Setup:")
-        print("1. Besuchen Sie: https://api.together.xyz/settings/api-keys")
+        print("1. Besuchen Sie: https://platform.moonshot.ai")
         print("2. Erstellen Sie einen API-Key")
         print("3. Setzen Sie ihn in der .env-Datei:")
-        print("   TOGETHER_API_KEY=your_actual_api_key_here")
+        print("   MOONSHOT_API_KEY=sk-your_actual_api_key_here")
         return False
     
     try:


### PR DESCRIPTION
## Summary
- drop `together` requirement
- switch `KimiClient` to Moonshot API using OpenAI library
- adjust start scripts and GUI/CLI helpers for `MOONSHOT_API_KEY`
- replace documentation and help text for Moonshot
- update tests and configuration

## Testing
- `pip install openai python-dotenv pydantic`
- `pip install requests`
- `PYTHONPATH=. pytest -q tests/test_tts.py`

------
https://chatgpt.com/codex/tasks/task_b_68850541fecc832294f10eedda521d1c